### PR TITLE
Fixes error when rescheduling existing key with Date object

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,10 +139,11 @@ Scheduler.prototype.schedule = function (options, cb) {
     if (options.expire) {
       var self = this;
       this.clients.scheduler.exists(options.key, function (err, exists) {
+        var expiresIn = self.getMillis(options.expire);
         if (exists) {
-          self.clients.scheduler.pexpire(options.key, options.expire, cb);
+          self.clients.scheduler.pexpire(options.key, expiresIn, cb);
         } else {
-          self.clients.scheduler.set(options.key, '', 'PX', self.getMillis(options.expire), cb);
+          self.clients.scheduler.set(options.key, '', 'PX', expiresIn, cb);
         }
       });
     }

--- a/test/index.js
+++ b/test/index.js
@@ -134,8 +134,32 @@ describe('Scheduler tests', function () {
       scheduler.end();
       client.del('test-job');
       done();
-    }});
-    scheduler.reschedule({ key: 'test-job', expire: 500 });
+    }}, function (err) {
+      should.not.exist(err);
+      scheduler.reschedule({ key: 'test-job', expire: 500 });
+    });
+  });
+
+  it('should be able to handle a reschedule of an event with datetime', function (done) {
+    var client = redis.createClient();
+    var timeout = setTimeout(function () {
+      throw new Error('shouldnt be here');
+    }, 1200);
+
+    var scheduler = new Scheduler({ host: 'localhost', port: 6379});
+    scheduler.schedule({ key: 'test-job', expire: new Date(Date.now() + 1000), handler: function (err, message) {
+      clearTimeout(timeout);
+      should.not.exist(err);
+      message.should.equal('test-job');
+      scheduler.end();
+      client.del('test-job');
+      done();
+    }}, function (err) {
+      should.not.exist(err);
+      scheduler.reschedule({ key: 'test-job', expire: new Date(Date.now() + 500) }, function (err) {
+        should.not.exist(err);
+      });
+    });
   });
 
   it('should be able to cancel an event', function (done) {


### PR DESCRIPTION
This was throwing a `value is not an integer or out of range` exception in the redis parser when rescheduling a key twice with a Date instance (since we weren't calling`getMillis` when calling `pexpire`, see #10)

As a bonus, the coverage is back to 💯🎉